### PR TITLE
chore: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,23 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16.x'
-    - run: npm ci
-    - run: npm run build
-    - run: npm test 
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - run: npm ci
+      - run: npm run build
+      - run: npm test


### PR DESCRIPTION
- Add minimum required permissions for CI workflow
  - contents: read (for checking out code)
  - pull-requests: write (for status checks)
- Follows GitHub security best practices
- Addresses CodeQL security warning about missing workflow permissions
- Implements principle of least privilege